### PR TITLE
Add mkdocs project documentation builder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+generated_docs_site

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # fsm_gen
 C-code FSM generator from YAML specifications
+
+# Docs
+There is a documentation system based on [mkdocs](https://www.mkdocs.org/getting-started/).
+
+## Install
+
+```bash
+pip install -r requirements.txt
+```
+## Build and run
+
+```bash
+mkdocs serve
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+# Generate FSM
+C-code FSM generator from YAML specifications
+
+<!--nav-->
+* [Home](README.md)
+* [Future plans](plans.md)

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,0 +1,22 @@
+site_name: VeriFSM
+
+docs_dir: ./docs
+site_dir: ./generated_docs_site
+
+theme:
+  name: 'material'
+  palette:
+    scheme: default
+    primary: indigo
+    accent: indigo
+  font:
+    text: Roboto
+    code: Roboto Mono
+
+plugins:
+  - search
+  - mkdocstrings
+  - literate-nav:
+      nav_file: README.md
+      implicit_index: true
+      tab_length: 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+# Python 3.8
+
+# Documentation management
+mkdocs==1.6.0
+
+# Material theme for mkdocs
+# https://squidfunk.github.io/mkdocs-material/getting-started/
+mkdocs-material==9.5.28
+
+# For auto-generating documentation from docstrings in code
+# https://mkdocstrings.github.io/
+mkdocstrings==0.25.1
+mkdocstrings-python==1.10.5
+
+# Navigation
+# https://oprypin.github.io/mkdocs-literate-nav/index.html
+mkdocs-literate-nav==0.6.1


### PR DESCRIPTION
This pull request adds [mkdocs](https://www.mkdocs.org/) project builder with some basic configuration.

Changes:
- Add file with python requirements to the root of the project.
- Add `mkdocs.yaml` configuration file.
- Add a theme and basic plugins.
- Update main README.md with a description how to install and run documentation server.
- TODO file was moved to docs folder and renamed to `plans`.
